### PR TITLE
Issue #2511618: Add an empty hook_boot() Implementation so Registry Rebuild will work

### DIFF
--- a/registry_autoload.module
+++ b/registry_autoload.module
@@ -6,6 +6,15 @@
 
 // Core hooks
 // --------------------------------------------------------------------------
+
+/**
+ * Implements hook_boot().
+ */
+function registry_autoload_boot() {
+  // Empty implementation so registry_rebuild can rebuild the registry in the
+  // bootstrap modules phase.
+}
+
 /**
  * Implements hook_module_implements_alter().
  */


### PR DESCRIPTION
Ticket: https://www.drupal.org/node/2511618

Add an empty hook_boot() Implementation so Registry Rebuild will work
